### PR TITLE
use typographic values for switches

### DIFF
--- a/.binder/jupyterlab-videochat/branding.json
+++ b/.binder/jupyterlab-videochat/branding.json
@@ -1,0 +1,6 @@
+{
+  "backgroundColor": "#003057",
+  "backgroundImageUrl": "https://raw.githubusercontent.com/gt-coar/jupyterlab-gt-coar-theme/master/style/img/wordmark.svg",
+  "logoClickUrl": "https://github.com/gt-coar/jupyterlab-gt-coar-theme",
+  "logoImageUrl": "https://raw.githubusercontent.com/gt-coar/jupyterlab-gt-coar-theme/master/style/img/wordmark.svg"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,23 @@
 
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { IThemeManager } from '@jupyterlab/apputils';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { LabIcon, jupyterFaviconIcon } from '@jupyterlab/ui-components';
 
-import { NS, NAME, GT_SVG, GT_ICON_ID } from './tokens';
+import {
+  NS,
+  NAME,
+  WORDMARK_SVG,
+  WORDMARK_ICON_ID,
+  CHEVRONS_URL,
+  WORDMARK_URL,
+} from './tokens';
 
-export const GT_ICON = new LabIcon({ name: GT_ICON_ID, svgstr: GT_SVG });
+export const GT_ICON = new LabIcon({ name: WORDMARK_ICON_ID, svgstr: WORDMARK_SVG });
 
 const OG_FAVICON = jupyterFaviconIcon.svgstr;
+const OG_FAVICON_MIME = 'image/x-icon';
+const GT_FAVICON_MIME = 'image/svg+xml';
 
 function makeTheme(value: string): JupyterFrontEndPlugin<void> {
   return {
@@ -21,20 +31,46 @@ function makeTheme(value: string): JupyterFrontEndPlugin<void> {
     activate: (app: JupyterFrontEnd, manager: IThemeManager) => {
       let wasLoaded = false;
       const isLight = value == 'Light';
+      let faviconIdle: HTMLLinkElement;
+      let faviconBusy: HTMLLinkElement;
+
+      let ogFaviconIdle: string;
+      let ogFaviconBusy: string;
+      const baseUrl = PageConfig.getBaseUrl();
+
+      function toggleFavicons(restore = false) {
+        if (faviconIdle == null) {
+          faviconIdle = document.querySelector('link.favicon.idle');
+          ogFaviconIdle = `${baseUrl}static/favicons/favicon.ico`;
+          faviconBusy = document.querySelector('link.favicon.busy');
+          ogFaviconBusy = `${baseUrl}static/favicons/favicon-busy-1.ico`;
+        }
+        if (restore) {
+          faviconIdle.href = ogFaviconIdle;
+          faviconBusy.href = ogFaviconBusy;
+          faviconIdle.type = faviconBusy.type = OG_FAVICON_MIME;
+          jupyterFaviconIcon.svgstr = OG_FAVICON;
+        } else {
+          faviconIdle.href = WORDMARK_URL;
+          faviconBusy.href = CHEVRONS_URL;
+          faviconIdle.type = faviconBusy.type = GT_FAVICON_MIME;
+          jupyterFaviconIcon.svgstr = WORDMARK_SVG;
+        }
+      }
 
       manager.register({
         name: `${NAME} ${value}`,
         isLight,
         themeScrollbars: !isLight,
         load: async () => {
-          jupyterFaviconIcon.svgstr = GT_SVG;
+          toggleFavicons();
           // avoid loading twice
           wasLoaded ? void 0 : manager.loadCSS(`${NS}/index.css`);
           wasLoaded = true;
         },
         unload: async () => {
-          if (jupyterFaviconIcon.svgstr === GT_SVG) {
-            jupyterFaviconIcon.svgstr = OG_FAVICON;
+          if (jupyterFaviconIcon.svgstr === WORDMARK_SVG) {
+            toggleFavicons(true);
           }
         },
       });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,11 +3,13 @@
 | Distributed under the terms of the BSD-3-Clause License.
 */
 
-import GT_SVG from '../style/img/wordmark.svg';
+import WORDMARK_SVG from '../style/img/wordmark.svg';
+import WORDMARK_URL from '!!file-loader?name=[path][name].[ext]&context=.!../style/img/wordmark.svg';
+import CHEVRONS_URL from '!!file-loader?name=[path][name].[ext]&context=.!../style/img/chevrons.svg';
 
 export const NS = '@gt-coar/jupyterlab-theme';
 export const NAME = 'GT COAR';
 
-export const GT_ICON_ID = `${NS}:wordmark`;
+export const WORDMARK_ICON_ID = `${NS}:wordmark`;
 
-export { GT_SVG };
+export { WORDMARK_URL, CHEVRONS_URL, WORDMARK_SVG };

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,3 +7,8 @@ declare module '*.svg' {
   const value: string;
   export default value;
 }
+
+declare module '!!file-loader*' {
+  const value: string;
+  export default value;
+}

--- a/style/dark.css
+++ b/style/dark.css
@@ -111,27 +111,3 @@ body[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false'] {
 [data-jp-theme-name*='GT COAR'][data-jp-theme-light='false'] .jp-InputArea-editor {
   border: 0;
 }
-
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false']
-  .jp-switch[aria-checked='true']
-  .jp-switch-track {
-  background-color: var(--jp-brand-color1);
-}
-
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false']
-  .jp-switch[aria-checked='true']
-  .jp-switch-track::before {
-  background-color: var(--gt-blue-link-hover);
-}
-
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false'] .jp-switch-track::before,
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false'] .jp-switch-track {
-  border: solid 1px var(--jp-brand-color1);
-}
-
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='false'] .jp-switch-track::before {
-  background-color: transparent;
-  margin: 2px 3px;
-  width: 9px;
-  height: 9px;
-}

--- a/style/img/chevrons.svg
+++ b/style/img/chevrons.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 40.119231 39.952085"
+   height="151"
+   width="151.63174">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-64.514317,-86.241856)"
+     id="layer1">
+    <g
+       transform="translate(-3.1576539e-7,-4.1057038)"
+       id="g853">
+      <path
+         id="path847"
+         d="m 81.183115,94.453263 9.12111,15.888287 -9.15238,15.85239 H 95.49581 l 9.13774,-15.82703 -9.23974,-15.913647 z"
+         style="fill:#b3a369;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         style="fill:#b3a369;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 64.545587,94.453263 9.12111,15.888287 -9.15238,15.85239 h 7.269719 l 9.13774,-15.82703 -9.23974,-15.913647 z"
+         id="path849" />
+    </g>
+  </g>
+</svg>

--- a/style/index.css
+++ b/style/index.css
@@ -221,32 +221,32 @@
 }
 
 [data-jp-theme-name*='GT COAR'] .jp-switch-track {
-  background-color: var(--jp-layout-color3);
+  background-color: var(--jp-layout-color4);
   width: 2em;
   height: 1em;
-  margin-right: 0.125em;
+  margin-right: 0.1em;
 }
 
 [data-jp-theme-name*='GT COAR'] .jp-switch-track::before {
-  background-color: var(--jp-layout-color0);
-  width: 0.75em;
-  height: 0.75em;
+  background-color: var(--gt-navy);
+  width: 1em;
+  height: 1em;
   margin: 0;
   border: 0;
-  top: 0.125em;
-  left: 0.125em;
+  top: 0;
+  left: 0;
 }
 
 [data-jp-theme-name*='GT COAR'] .jp-switch[aria-checked='true'] .jp-switch-track {
-  background-color: var(--jp-layout-color3);
+  background-color: var(--jp-layout-color4);
 }
 
 [data-jp-theme-name*='GT COAR']
   .jp-switch[aria-checked='true']
   .jp-switch-track::before {
-  right: 0.125em;
+  right: 0;
   left: unset;
-  background-color: var(--gt-blue-link-hover);
+  background-color: var(--gt-gold-buzz-60);
 }
 
 /* debugger */

--- a/style/index.css
+++ b/style/index.css
@@ -215,6 +215,40 @@
   border-top: var(--jp-border-width) solid var(--gt-gold-buzz);
 }
 
+/* switch */
+[data-jp-theme-name*='GT COAR'] .jp-switch {
+  height: unset;
+}
+
+[data-jp-theme-name*='GT COAR'] .jp-switch-track {
+  background-color: var(--jp-layout-color3);
+  width: 2em;
+  height: 1em;
+  margin-right: 0.125em;
+}
+
+[data-jp-theme-name*='GT COAR'] .jp-switch-track::before {
+  background-color: var(--jp-layout-color0);
+  width: 0.75em;
+  height: 0.75em;
+  margin: 0;
+  border: 0;
+  top: 0.125em;
+  left: 0.125em;
+}
+
+[data-jp-theme-name*='GT COAR'] .jp-switch[aria-checked='true'] .jp-switch-track {
+  background-color: var(--jp-layout-color3);
+}
+
+[data-jp-theme-name*='GT COAR']
+  .jp-switch[aria-checked='true']
+  .jp-switch-track::before {
+  right: 0.125em;
+  left: unset;
+  background-color: var(--gt-blue-link-hover);
+}
+
 /* debugger */
 [data-jp-theme-name*='GT COAR'] .jp-DebuggerCallstack-body ul li.selected {
   font-weight: 700;

--- a/style/light.css
+++ b/style/light.css
@@ -95,9 +95,3 @@
   .lm-MenuBar-item.lm-mod-active {
   border-top: var(--jp-border-width) solid var(--gt-gold-buzz);
 }
-
-[data-jp-theme-name*='GT COAR'][data-jp-theme-light='true']
-  .jp-switch[aria-checked='true']
-  .jp-switch-track {
-  background-color: var(--gt-blue-link-hover);
-}


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nrbgt/jupyterlab-gt-coar-theme/gh-5-unjank-switches?urlpath=lab)

- fixes #5

Uses `em` for switches.